### PR TITLE
fix: add .vercel to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 !.env.example
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+.vercel


### PR DESCRIPTION
This directory is an artifact/output directory and shouldn't be replicated across git, and we've already had an instance of secrets being leaked by this.

It's being made because of the vercel adapter.