### PR TITLE
update community groups sidebar to make the entire `li` clickable. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ To contribute please follow the [contributing](./CONTRIBUTING.md) guide.
 ## Development Environment
 
 1. Install [mongodb v7.x.x Community Edition](https://www.mongodb.com/docs/manual/installation/) if not already installed locally.
+
    1. [Mac](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-os-x/)
       1. [Start the database](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-os-x/#run-mongodb-community-edition)
    2. [Windows](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-windows/)
       1. [Start the database](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-windows/#run-mongodb-community-edition-as-a-windows-service)
+
 2. Copy example env to get local up and running.
 
 ```sh
@@ -64,29 +66,34 @@ cp .env.example .env.local
 
 **Note: On node >=17, you'll need to replace localhost with 0.0.0.0 ([src](https://stackoverflow.com/questions/46523321/mongoerror-connect-econnrefused-127-0-0-127017))**
 
-4. Install dependencies and start app
+4. Install Dependencies and seed Database
 
 ```sh
 npm i
+npm run seed
+```
+
+5. Start app. It will run the web app in a _development_ node environment, meaning that it will not load any external resources which may require secrets (API Keys, etc).
+
+```sh
 npm run dev
 ```
 
-5. This will run the web app under a _development_ node environment, meaning that it will not load any external resources which may require secrets (API Keys, etc).
-6. You now should be up and running to start developing 🥸
+1. You now should be up and running to start developing 🥸
 
 ## Production Environment
 
 ### API Keys you will need
 
-| name                  | env key         | env value                                                                                                                                              |
-| --------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Google Calendar API   | `CAL`           | [Follow these steps](#google-calendar-api-key)                                                                                                         |
-| Discord Webhook URL   | `DISCORD`       | Apply for [Contributor Access](https://discord.com/channels/1117944495099613254/1166366239652847687/1166367256356335636) if you don't have it already. |
-| Mapbox Public API Key | `PUBLIC_MAPBOX` | [Follow these steps](#mapbox-public-key)                                                                                                               |
-| Cron Secret           | `CRON_SECERT`   | This is an arbitary value, For local testing set and use in Postman or other API testing tool                                                          |
-| mongodb name          | `DB_NAME`       | `noladevs`                                                                                                                                             |
-| mongodb URL           | `MONGO_URL`     | `mongodb://localhost:27017/`                                                                                                                           |
-| Discord Webhook URL   | `DISCORD_WEBHOOK_URL`     | A webhook Channel URL                                                                                                                 |
+| name                  | env key               | env value                                                                                                                                              |
+| --------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Google Calendar API   | `CAL`                 | [Follow these steps](#google-calendar-api-key)                                                                                                         |
+| Discord Webhook URL   | `DISCORD`             | Apply for [Contributor Access](https://discord.com/channels/1117944495099613254/1166366239652847687/1166367256356335636) if you don't have it already. |
+| Mapbox Public API Key | `PUBLIC_MAPBOX`       | [Follow these steps](#mapbox-public-key)                                                                                                               |
+| Cron Secret           | `CRON_SECERT`         | This is an arbitary value, For local testing set and use in Postman or other API testing tool                                                          |
+| mongodb name          | `DB_NAME`             | `noladevs`                                                                                                                                             |
+| mongodb URL           | `MONGO_URL`           | `mongodb://localhost:27017/`                                                                                                                           |
+| Discord Webhook URL   | `DISCORD_WEBHOOK_URL` | A webhook Channel URL                                                                                                                                  |
 
 Make sure you have created the above keys with provided values or your own where indicated.
 Once you have both created (copy `.env.example`) and added to your `.env.local` file (or any other equivalent environment variable system), you can actually deploy it. (_instructions in hyperlinks_)

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
 				"vitest": "^0.32.2"
 			},
 			"engines": {
-				"node": ">20.6.0"
+				"node": ">=20.6.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
 				"vitest": "^0.32.2"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">20.6.0"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,9 @@
 				"typescript": "^5.0.0",
 				"vite": "~4.5.1",
 				"vitest": "^0.32.2"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
-		"seed": "node --env-file=.env ./src/lib/scripts/seed.js",
+		"seed": "node --env-file=.env.local ./src/lib/scripts/seed.js",
 		"test": "npm run test:integration && npm run test:unit",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
@@ -56,5 +56,8 @@
 		"bcrypt": "^5.1.1",
 		"ics": "^3.7.2",
 		"tailwind-merge": "^2.2.2"
+	},
+	"engines": {
+		"node": ">20"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
 		"tailwind-merge": "^2.2.2"
 	},
 	"engines": {
-		"node": ">20"
+		"node": ">20.6.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
 		"tailwind-merge": "^2.2.2"
 	},
 	"engines": {
-		"node": ">20.6.0"
+		"node": ">=20.6.0"
 	}
 }

--- a/src/lib/components/sidebar.svelte
+++ b/src/lib/components/sidebar.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	//import Icon from '$lib/components/icon/index.svelte';
-	import { groupIconsMap } from '$lib/components/icon/icons';
 	import { NavBrand } from 'flowbite-svelte';
 
 	export let data: { groups: { name: string; slug: string; icon: string }[] };
@@ -24,16 +22,9 @@
 					<a
 						data-sveltekit-reload
 						href="/group/{slug}"
-						class="inline-flex items-center justify-start gap-3 py-2 px-4 text-base font-medium leading-[24px] group-hover:text-white text-gray-900 dark:text-white"
+						class="inline-flex items-center justify-start gap-3 py-2 px-4 text-base font-medium leading-[24px] group-hover:text-white text-gray-900 dark:text-white w-full h-full"
 						aria-label="{`Group ${name}`}"
 					>
-						<!-- {#if groupIconsMap[slug]}
-							<Icon
-								name="{groupIconsMap[slug]}"
-								size="{24}"
-								className="text-gray-500 dark:text-violet-300 group-hover:text-white"
-							/>
-						{/if} -->
 						<span class="text-base font-medium leading-[24px]">{icon} {name}</span>
 					</a>
 				</li>


### PR DESCRIPTION
# 🚀 Description

This PR tackles a few different items.
1. When in desktop mode the commnuity groups were only clickable over the text. This change allow the entire highlighted area to be clickable.
2. With the command `npm run seed` uses `--env-file` [flag](https://nodejs.org/en/blog/release/v20.6.0) which requires node version `20.6.0` or greater. This change requires the dev to have at least that version of node installed. 
3. Update README to help new users get up to speed faster. :)

## 💻 Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## 📝 How has this been tested and how can we Reproduce?

Running a local version of the app. Can I click on the purple bar and does it take me to the correct page? 

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have included in my PR description where corresponding changes to the documentation are needed
