### PR TITLE
fix #105: repair organizer icon links

### DIFF
--- a/src/lib/components/organizer-list.svelte
+++ b/src/lib/components/organizer-list.svelte
@@ -26,8 +26,8 @@
 					<a href="mailto:{email}">
 						<Icon name="mailIcon" size="{18}" viewBox="0 0 23 16" />
 					</a>
-					{#each Object.keys(links) as link}
-						<a href="{links.link}" target="_blank">
+					{#each Object.entries(links) as [link, url]}
+						<a href="{url}" target="_blank">
 							<IconParse icon="{link}" />
 						</a>
 					{/each}

--- a/src/lib/db/models/users.model.ts
+++ b/src/lib/db/models/users.model.ts
@@ -11,7 +11,8 @@ const UserSchema = new Schema<User>({
 		required: false
 	},
 	links: {
-		type: Object,
+		type: Map,
+		of: String,
 		required: false
 	},
 	email: {

--- a/src/routes/(app)/about/+page.svelte
+++ b/src/routes/(app)/about/+page.svelte
@@ -65,8 +65,8 @@
 						<a href="mailto:{email}">
 							<Icon name="mailIcon" size="{18}" viewBox="0 0 23 16" />
 						</a>
-						{#each Object.keys(links) as link}
-							<a href="{links.link}" target="_blank">
+						{#each Object.entries(links) as [link, url]}
+							<a href="{url}" target="_blank">
 								<IconParse icon="{link}" />
 							</a>
 						{/each}


### PR DESCRIPTION
# 🚀 Description

This PR addresses the issue where only the email icon was functioning in the organizer's section. The fix includes correctly linking the GitHub, LinkedIn, and other relevant icons to their respective profiles.

**Resolves:** #105

The changes were tested by following these steps:
1. **Step 1:** Click on an event from the home page.
2. **Step 2:** In the right-side panel under "Organizers," click each icon (GitHub, LinkedIn, email, etc.) next to the organizer's profile picture.
3. **Expected Outcome:** All icons should correctly link to their respective URLs (e.g., GitHub profile, LinkedIn profile, email client).

![org](https://github.com/user-attachments/assets/0b36dcfa-bf30-41ab-b78d-ff01d52c5fcf)
