### PR TITLE
fix(navbar): close menu on link click

### DIFF
--- a/src/lib/components/mobile-menu.svelte
+++ b/src/lib/components/mobile-menu.svelte
@@ -23,6 +23,7 @@
 		easing: sineIn
 	};
 
+	const closeSidebar = () => (hidden = true);
 	const getGroupPath = (slug: string) => `/group/${slug}`;
 </script>
 
@@ -40,9 +41,11 @@
 			href="/"
 			class="inline-flex items-center  font-cute text-5xl leading-10 text-gray-900 dark:text-violet-100"
 		>
-			N0LA<span class="text-[#6628CC]">{'[DEVS]'}</span>
+			<button on:click="{closeSidebar}">
+				N0LA<span class="text-[#6628CC]">{'[DEVS]'}</span>
+			</button>
 		</NavBrand>
-		<CloseButton on:click="{() => (hidden = true)}" class="mb-4 dark:text-white" />
+		<CloseButton on:click="{closeSidebar}" class="mb-4 dark:text-white" />
 	</div>
 	<Sidebar>
 		<SidebarWrapper divClass="overflow-y-auto py-4 px-3 rounded ">
@@ -51,7 +54,7 @@
 				{#each data.groups as { name, slug, icon }}
 					<SidebarItem
 						data-sveltekit-reload
-						on:click="{() => (hidden = true)}"
+						on:click="{closeSidebar}"
 						href="{getGroupPath(slug)}"
 						label="{`${icon} ${name}`}"
 						class="group dark:hover:text-white hover:text-white hover:bg-purple-700 font-medium dark:hover:bg-purple-700"
@@ -76,12 +79,14 @@
 				label="About"
 				class="font-base px-2 py-1 hover:bg-transparent dark:hover:bg-transparent leading-[24px] text-gray-400 hover:text-gray-600 dark:text-violet-100 dark:hover:text-violet-300"
 				spanClass=""
+				on:click="{closeSidebar}"
 			></SidebarItem>
 			<SidebarItem
 				href="/contact"
 				label="Contact"
 				class="font-base px-2 py-1 hover:bg-transparent dark:hover:bg-transparent leading-[24px] text-gray-400 hover:text-gray-600 dark:text-violet-100 dark:hover:text-violet-300"
 				spanClass=""
+				on:click="{closeSidebar}"
 			></SidebarItem>
 			<DarkMode btnClass="ml-5">
 				<Icon name="moonIcon" slot="darkIcon" size="{24}" />


### PR DESCRIPTION
# 🚀 Description

This pull request addresses issue #111, which is related to the mobile navbar not closing automatically after a navigation link is clicked. The change implements an event listener that triggers the navbar to close when a user clicks on any navigation link. This enhances the user experience by ensuring that the navigation menu does not remain open unnecessarily, providing a smoother and more intuitive navigation process.

## 💻 Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## 📝 How has this been tested and how can we Reproduce?

To test the changes and ensure the navbar closes correctly:

1. **Navigate to the mobile view** of the application (resize the browser or use a mobile device emulator).
2. **Open the mobile navbar menu** by clicking the hamburger icon.
3. **Click on any navigation link** within the menu.
4. **Verify** that the navbar menu automatically closes after the link is clicked.

**Test Configuration:**
- Browser: [e.g., Chrome, Firefox]
- Operating System: [e.g., Windows 10, macOS 11]

## 📸 Any screenshots or links to points in your code or references elsewhere as needed

![ResponsiveMobileNavbar](https://github.com/user-attachments/assets/19677833-5a4d-4235-a54d-fc1d6f79b382)

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have included in my PR description where corresponding changes to the documentation are needed
