### PR TITLE
#118: add Vercel Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"@types/sanitize-html": "^2.9.5",
 				"@typescript-eslint/eslint-plugin": "^6.0.0",
 				"@typescript-eslint/parser": "^6.0.0",
-				"@vercel/analytics": "^1.1.1",
+				"@vercel/analytics": "^1.3.1",
 				"@vercel/node": "^3.0.11",
 				"autoprefixer": "^10.4.16",
 				"eslint": "^8.28.0",
@@ -1487,10 +1487,11 @@
 			"dev": true
 		},
 		"node_modules/@vercel/analytics": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.2.2.tgz",
-			"integrity": "sha512-X0rctVWkQV1e5Y300ehVNqpOfSOufo7ieA5PIdna8yX/U7Vjz0GFsGf4qvAhxV02uQ2CVt7GYcrFfddXXK2Y4A==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.3.1.tgz",
+			"integrity": "sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==",
 			"dev": true,
+			"license": "MPL-2.0",
 			"dependencies": {
 				"server-only": "^0.0.1"
 			},
@@ -8043,9 +8044,9 @@
 			"dev": true
 		},
 		"@vercel/analytics": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.2.2.tgz",
-			"integrity": "sha512-X0rctVWkQV1e5Y300ehVNqpOfSOufo7ieA5PIdna8yX/U7Vjz0GFsGf4qvAhxV02uQ2CVt7GYcrFfddXXK2Y4A==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.3.1.tgz",
+			"integrity": "sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==",
 			"dev": true,
 			"requires": {
 				"server-only": "^0.0.1"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@types/sanitize-html": "^2.9.5",
 		"@typescript-eslint/eslint-plugin": "^6.0.0",
 		"@typescript-eslint/parser": "^6.0.0",
-		"@vercel/analytics": "^1.1.1",
+		"@vercel/analytics": "^1.3.1",
 		"@vercel/node": "^3.0.11",
 		"autoprefixer": "^10.4.16",
 		"eslint": "^8.28.0",

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -1,6 +1,10 @@
 import GroupModel from '$lib/db/models/groups.model';
 import type { LayoutServerLoad } from './$types';
 
+import { dev } from '$app/environment';
+import { inject } from '@vercel/analytics';
+inject({ mode: dev ? 'development' : 'production' })
+
 export const load: LayoutServerLoad = async () => {
 	const groupsData = await GroupModel.find({}, 'group slug icon -_id').lean();
 

--- a/src/routes/(app)/+layout.server.ts
+++ b/src/routes/(app)/+layout.server.ts
@@ -1,10 +1,6 @@
 import GroupModel from '$lib/db/models/groups.model';
 import type { LayoutServerLoad } from './$types';
 
-import { dev } from '$app/environment';
-import { inject } from '@vercel/analytics';
-inject({ mode: dev ? 'development' : 'production' })
-
 export const load: LayoutServerLoad = async () => {
 	const groupsData = await GroupModel.find({}, 'group slug icon -_id').lean();
 

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -8,6 +8,10 @@
 	import type { LayoutData } from './$types';
 	export let data: LayoutData;
 
+	import { dev } from '$app/environment';
+	import { inject } from '@vercel/analytics';
+	inject({ mode: dev ? 'development' : 'production' })
+
 	// TODO: Add to cookies for alert if dismissed or done to not show again
 </script>
 


### PR DESCRIPTION
# 🚀 Description

Vercel Analytics script added to +layout.svelte. Once Analytics is enabled in Vercel dashboard, site visitors and page visits will be tracked.

Resolves # 118

## 💻 Type of change

- [x] New feature (non-breaking change which adds functionality)

## 📝 How has this been tested and how can we Reproduce?

Spun up my own deployment on Vercel based on my fork of noladevs, analytics are currently functional. To reproduce, a Vercel deployment is required and analytics need to be enabled in Vercel dashboard. Vercel can be configured to deploy from a branch, I deployed from the i-118 branch to test. Analytics tab for my deployment (visited the app from two devices, clicked around some pages):
![image](https://github.com/user-attachments/assets/6583d5b1-38a6-4b1c-b57f-ec7320aac4e0)


## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have included in my PR description where corresponding changes to the documentation are needed
