### PR TITLE
Update community slack invite link

### DIFF
--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -15,7 +15,7 @@
 		title="Developers, Designers, Lend Me Your Ears"
 		description="We’re a community of developers, entrepreneurs, students, and enthusiasts who are excited about the future of technology.  Join us to share projects, attend events, and learn something new!"
 		linkText="Community Slack"
-		linkHref="https://join.slack.com/t/nola/shared_invite/zt-2zeiwayiv-pmIaaaYAV1SmYSx5m5en6w"
+		linkHref="https://join.slack.com/t/nola/shared_invite/zt-31zf5522p-QgwI5Mca_he6jku5xfGVlA"
 		linkIcon="slackIcon"
 		bannerClass="bg-homeBanner text-white"
 	/>


### PR DESCRIPTION
UPDATES SLACK INVITE LINK

- link valid for 30 days (tried changing to "Never Expires" in slack but did not work)