### PR TITLE
fix: filter out duplicate hack night event on home page

### DIFF
--- a/src/routes/(app)/+page.server.ts
+++ b/src/routes/(app)/+page.server.ts
@@ -7,9 +7,12 @@ import type { Event } from '$lib/types/event.d.ts';
 
 export const load: PageServerLoad = async () => {
 	try {
-		const events: Event[] = (await eventController.getEvents()).sort(
-			(a, b) => a.start.getTime() - b.start.getTime()
-		);
+		const events: Event[] = (await eventController.getEvents())
+			.sort((a, b) => a.start.getTime() - b.start.getTime())
+			.filter((event) => {
+				// avoid duplicate 'Hack Night' event on the events list
+				return !(event.group === 'Nola Game Dev' && event.summary === 'Hack Night');
+			});
 
 		return {
 			events


### PR DESCRIPTION
# 🚀 Description

Avoids duplicate Hack Night event on landing page. NOLA Game Dev has the same Hack Night meetup as the main Hack Night event. Their upcoming Hack Nights will be listed on their group page but no longer on the landing page in order to reduce confusion and noise on landing page.

Resolves #124 

## 💻 Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## 📸 Any screenshots or links to points in your code or references elsewhere as needed

### BEFORE:
<img width="1129" height="460" alt="image" src="https://github.com/user-attachments/assets/6adab6c6-fb45-4657-8632-fd384772e63d" />

### AFTER:
<img width="491" height="485" alt="image" src="https://github.com/user-attachments/assets/da97940d-5053-4af4-8dac-3388d75be133" />

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have included in my PR description where corresponding changes to the documentation are needed
