### PR TITLE
clean up expired events from event list

### DIFF
--- a/src/lib/db/models/events.model.ts
+++ b/src/lib/db/models/events.model.ts
@@ -22,6 +22,9 @@ const eventSchema = new Schema<Event>({
 		type: Date,
 		required: true
 	},
+	expireAt: {
+		type: Date
+	},
 	location: {
 		name: { type: String, required: true },
 		street: { type: String },
@@ -60,6 +63,9 @@ const eventSchema = new Schema<Event>({
 		required: true
 	}
 });
+
+// mongodb will clean up expired events with this index
+eventSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
 
 const EventModel = mongoose.models.Event || model('Event', eventSchema);
 

--- a/src/lib/scripts/addEvents.js
+++ b/src/lib/scripts/addEvents.js
@@ -22,6 +22,9 @@ const eventSchema = new Schema({
 		type: Date,
 		required: true
 	},
+	expireAt: {
+		type: Date
+	},
 	location: {
 		name: { type: String, required: true },
 		street: { type: String },
@@ -61,6 +64,9 @@ const eventSchema = new Schema({
 	}
 });
 
+// mongodb will clean up expired events with this index
+eventSchema.index({ expireAt: 1 }, { expireAfterSeconds: 0 });
+
 const EventModel = model('Event', eventSchema);
 
 export const loadEvents = async () => {
@@ -68,5 +74,6 @@ export const loadEvents = async () => {
 	const events = JSON.parse(data);
 
 	await EventModel.collection.drop();
+	await EventModel.syncIndexes(); // ensures index is included after the collection was dropped
 	await EventModel.bulkSave(events.map((e) => new EventModel(e)));
 };

--- a/src/lib/scripts/data/events.json
+++ b/src/lib/scripts/data/events.json
@@ -5,6 +5,7 @@
 		"description": "THIS MONTH:\n\n📅 Date: 10/14 🎉\n🚪 Doors at 5:30,\n⏰ Talk at 6:00\n📍 Scale New Orleans, 612 Andrew Higgins Dr 2nd floor, New Orleans, LA 70130\n\nNola Coders, we will now be doing a single \"Feature Speaker\" presenting a 5 - 15 min lightening talk with \"BYOB\" (Bring Your Own Bug) and some round-robin pair-programming for the remainder of the event. Bring anything you would love a pair of eyes on (extra points for front end). We are also going to do a bit of Show N Tell re: Your Developer Workflows: config and rc files, $profiles, code snippets, tools, plugins and anything you have implemented or enjoyed that optimizes your work as a dev ⚡⚡⚡️",
 		"start": "2026-03-10T23:00:00Z",
 		"end": "2026-03-11T01:00:00Z",
+		"expireAt": "2026-03-12T00:01:00Z",
 		"location": {
 			"name": "Scale New Orleans",
 			"street": "612 Andrew Higgins Dr 2nd floor",
@@ -24,6 +25,7 @@
 		"description": "We typically convene on the street. If it's raining we may be inside or in the courtyard. We'll do our best to notice and greet you, but there is no hack night uniform. So if you see a group of nerds arguing in the street just ask \"Is this Hack Night?\" and they will greet you and introduce you to people.People show up between 7 and 8. There is no actual start time.",
 		"start": "2026-03-11T00:00:00Z",
 		"end": "2026-03-11T02:00:00Z",
+		"expireAt": "2026-03-12T00:01:00Z",
 		"location": {
 			"name": "The Rusty Nail",
 			"street": "1100 Constance St",
@@ -43,6 +45,7 @@
 		"description": "We typically convene on the street. If it's raining we may be inside or in the courtyard. We'll do our best to notice and greet you, but there is no hack night uniform. So if you see a group of nerds arguing in the street just ask \"Is this Hack Night?\" and they will greet you and introduce you to people.People show up between 7 and 8. There is no actual start time.",
 		"start": "2026-03-18T00:00:00Z",
 		"end": "2026-03-18T02:00:00Z",
+		"expireAt": "2026-03-19T00:01:00Z",
 		"location": {
 			"name": "The Rusty Nail",
 			"street": "1100 Constance St",
@@ -62,6 +65,7 @@
 		"description": "We typically convene on the street. If it's raining we may be inside or in the courtyard. We'll do our best to notice and greet you, but there is no hack night uniform. So if you see a group of nerds arguing in the street just ask \"Is this Hack Night?\" and they will greet you and introduce you to people.People show up between 7 and 8. There is no actual start time.",
 		"start": "2026-03-25T00:00:00Z",
 		"end": "2026-03-25T02:00:00Z",
+		"expireAt": "2026-03-26T00:01:00Z",
 		"location": {
 			"name": "The Rusty Nail",
 			"street": "1100 Constance St",
@@ -81,6 +85,7 @@
 		"description": "We typically convene on the street. If it's raining we may be inside or in the courtyard. We'll do our best to notice and greet you, but there is no hack night uniform. So if you see a group of nerds arguing in the street just ask \"Is this Hack Night?\" and they will greet you and introduce you to people.People show up between 7 and 8. There is no actual start time.",
 		"start": "2026-04-01T00:00:00Z",
 		"end": "2026-04-01T02:00:00Z",
+		"expireAt": "2026-04-02T00:01:00Z",
 		"location": {
 			"name": "The Rusty Nail",
 			"street": "1100 Constance St",
@@ -100,6 +105,7 @@
 		"description": "We typically convene on the street. If it's raining we may be inside or in the courtyard. We'll do our best to notice and greet you, but there is no hack night uniform. So if you see a group of nerds arguing in the street just ask \"Is this Hack Night?\" and they will greet you and introduce you to people.People show up between 7 and 8. There is no actual start time.",
 		"start": "2026-03-11T00:00:00Z",
 		"end": "2026-03-11T02:00:00Z",
+		"expireAt": "2026-03-12T00:01:00Z",
 		"location": {
 			"name": "The Rusty Nail",
 			"street": "1100 Constance St",
@@ -119,6 +125,7 @@
 		"description": "We typically convene on the street. If it's raining we may be inside or in the courtyard. We'll do our best to notice and greet you, but there is no hack night uniform. So if you see a group of nerds arguing in the street just ask \"Is this Hack Night?\" and they will greet you and introduce you to people.People show up between 7 and 8. There is no actual start time.",
 		"start": "2026-03-18T00:00:00Z",
 		"end": "2026-03-18T02:00:00Z",
+		"expireAt": "2026-03-19T00:01:00Z",
 		"location": {
 			"name": "The Rusty Nail",
 			"street": "1100 Constance St",
@@ -138,6 +145,7 @@
 		"description": "We typically convene on the street. If it's raining we may be inside or in the courtyard. We'll do our best to notice and greet you, but there is no hack night uniform. So if you see a group of nerds arguing in the street just ask \"Is this Hack Night?\" and they will greet you and introduce you to people.People show up between 7 and 8. There is no actual start time.",
 		"start": "2026-03-25T00:00:00Z",
 		"end": "2026-03-25T02:00:00Z",
+		"expireAt": "2026-03-26T00:01:00Z",
 		"location": {
 			"name": "The Rusty Nail",
 			"street": "1100 Constance St",
@@ -157,6 +165,7 @@
 		"description": "We typically convene on the street. If it's raining we may be inside or in the courtyard. We'll do our best to notice and greet you, but there is no hack night uniform. So if you see a group of nerds arguing in the street just ask \"Is this Hack Night?\" and they will greet you and introduce you to people.People show up between 7 and 8. There is no actual start time.",
 		"start": "2026-04-01T00:00:00Z",
 		"end": "2026-04-01T02:00:00Z",
+		"expireAt": "2026-04-02T00:01:00Z",
 		"location": {
 			"name": "The Rusty Nail",
 			"street": "1100 Constance St",
@@ -176,6 +185,7 @@
 		"description": "Join Cliff Barbier, Security Architect, for a discussion around security resilience. With perspectives of prevention, zero trust and more, we'll discuss how resilience supports business goals!\n",
 		"start": "2026-03-11T23:00:00Z",
 		"end": "2026-03-12T00:45:00Z",
+		"expireAt": "2026-03-13T00:01:00Z",
 		"location": {
 			"name": "Sidecar Patio & Oyster Bar",
 			"street": "1114 Constance St",

--- a/src/lib/scripts/seed.js
+++ b/src/lib/scripts/seed.js
@@ -17,7 +17,6 @@ export const connectDB = async () => {
 	}
 };
 
-console.log('test');
 try {
 	await connectDB();
 	await loadGroups();

--- a/src/lib/types/event.d.ts
+++ b/src/lib/types/event.d.ts
@@ -6,6 +6,7 @@ export interface Event {
 	description: string;
 	start: Date;
 	end: Date;
+	expireAt: Date;
 	location: EventLocation;
 	locationNotes?: string;
 	eventLink?: string;

--- a/src/routes/api/slack/eventbot/submit/+server.ts
+++ b/src/routes/api/slack/eventbot/submit/+server.ts
@@ -235,8 +235,8 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 			locationZip = zip;
 		}
 
-		const startDate = startTime ? new Date(startTime * 1000) : null;
-		const endDate = endTime ? new Date(endTime * 1000) : null;
+		const startDate = new Date(startTime * 1000);
+		const endDate = new Date(endTime * 1000);
 
 		const eventData = {
 			title,
@@ -260,6 +260,13 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 			createdAt: new Date()
 		};
 
+		const setExpireAt = (eventEnd: Date) => {
+			const expirationDate = new Date(eventEnd);
+			expirationDate.setUTCDate(expirationDate.getUTCDate() + 1);
+			expirationDate.setUTCHours(0);
+			return expirationDate;
+		};
+
 		const eventSlug = slugify(`${groupName} ${eventData.startTime}`, {
 			replacement: '-',
 			lower: true,
@@ -274,6 +281,7 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 			description: eventData.description,
 			start: eventData.startTime,
 			end: eventData.endTime,
+			expireAt: setExpireAt(eventData.endTime),
 			location: {
 				name: eventData.locationName,
 				street: eventData.streetAddress,


### PR DESCRIPTION
# 🚀 Description

Adds an expiration date for the events and corresponding index so that MongoDB will automatically delete them as they expire.

Resolves #158 

## 💻 Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## 📝 How has this been tested and how can we Reproduce?

- [ ] Run the app
- [ ] seed the database
- [ ] check for correct index with `mongosh`: `db.events.getIndexes()`. Create the index if not present: `db.events.createIndex({ expireAt: 1 }, { expireAfterSeconds: 0 })`
- [ ] confirm expired events are not present in db or on event list. (mongo runs the cleanup every ~60s)

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas