### PR TITLE
fix silent fail when missing event information

### DIFF
--- a/src/lib/db/models/events.model.ts
+++ b/src/lib/db/models/events.model.ts
@@ -56,7 +56,7 @@ const eventSchema = new Schema<Event>({
 	},
 	groupSlug: {
 		type: String,
-		required: false
+		required: true
 	},
 	createdAt: {
 		type: Date,

--- a/src/lib/utils/eventbot.ts
+++ b/src/lib/utils/eventbot.ts
@@ -10,6 +10,7 @@ type createEventModalBlocksOptions = {
 	locations: Array<{ text: string; value: string }>;
 	showOtherGroupField?: boolean;
 	showOtherLocationFields?: boolean;
+	isMissingField?: boolean;
 };
 
 export const createGroupOptions = (fetchedGroups: Group[]) => {
@@ -95,14 +96,25 @@ export const buildAnnouncementBlocks = (event: any) => {
  * fields appear when an 'Other' option is selected.
  */
 export const buildCreateEventModalBlocks = (options: createEventModalBlocksOptions) => {
-	const { groups, locations, showOtherGroupField, showOtherLocationFields } = options;
+	const { groups, locations, showOtherGroupField, showOtherLocationFields, isMissingField } =
+		options;
 
 	const blocks = [
+		{
+			type: 'context',
+			block_id: 'required_fields_note',
+			elements: [
+				{
+					type: 'mrkdwn',
+					text: 'Fields marked with * are required'
+				}
+			]
+		},
 		{
 			// Meetup title
 			type: 'input',
 			block_id: 'title_block',
-			label: { type: 'plain_text', text: 'Meetup Title' },
+			label: { type: 'plain_text', text: '* Meetup Title' },
 			element: {
 				type: 'plain_text_input',
 				action_id: 'title_input',
@@ -114,7 +126,7 @@ export const buildCreateEventModalBlocks = (options: createEventModalBlocksOptio
 			// Group select
 			type: 'section',
 			block_id: 'group_section_block',
-			text: { type: 'mrkdwn', text: '*Group*' },
+			text: { type: 'mrkdwn', text: '* *Group*' },
 			accessory: {
 				type: 'static_select',
 				action_id: 'group_select',
@@ -133,13 +145,23 @@ export const buildCreateEventModalBlocks = (options: createEventModalBlocksOptio
 		}
 	];
 
+	if (isMissingField) {
+		blocks.unshift({
+			type: 'context',
+			block_id: 'required_error_block',
+			elements: [
+				{ type: 'mrkdwn', text: ':warning: Please fill in all required fields (*) :warning: ' }
+			]
+		});
+	}
+
 	if (showOtherGroupField) {
 		blocks.push({
 			type: 'input',
 			block_id: 'other_group_block',
 			label: {
 				type: 'plain_text',
-				text: 'Group Name'
+				text: '* Group Name'
 			},
 			element: {
 				type: 'plain_text_input',
@@ -157,7 +179,7 @@ export const buildCreateEventModalBlocks = (options: createEventModalBlocksOptio
 	blocks.push({
 		type: 'input',
 		block_id: 'description_block',
-		label: { type: 'plain_text', text: 'Meetup Description' },
+		label: { type: 'plain_text', text: '* Meetup Description' },
 		element: {
 			type: 'plain_text_input',
 			action_id: 'description_input',
@@ -172,7 +194,7 @@ export const buildCreateEventModalBlocks = (options: createEventModalBlocksOptio
 		{
 			type: 'input',
 			block_id: 'starttime_block',
-			label: { type: 'plain_text', text: 'Start' },
+			label: { type: 'plain_text', text: '* Start' },
 			element: {
 				type: 'datetimepicker',
 				action_id: 'datetimepicker_start'
@@ -182,7 +204,7 @@ export const buildCreateEventModalBlocks = (options: createEventModalBlocksOptio
 		{
 			type: 'input',
 			block_id: 'endtime_block',
-			label: { type: 'plain_text', text: 'End' },
+			label: { type: 'plain_text', text: '* End' },
 			element: {
 				type: 'datetimepicker',
 				action_id: 'datetimepicker_end'
@@ -195,7 +217,7 @@ export const buildCreateEventModalBlocks = (options: createEventModalBlocksOptio
 	blocks.push({
 		type: 'section',
 		block_id: 'location_section_block',
-		text: { type: 'mrkdwn', text: '*Location*' },
+		text: { type: 'mrkdwn', text: '* *Location*' },
 		accessory: {
 			type: 'static_select',
 			action_id: 'location_select',
@@ -219,7 +241,7 @@ export const buildCreateEventModalBlocks = (options: createEventModalBlocksOptio
 			{
 				type: 'input',
 				block_id: 'location_name_block',
-				label: { type: 'plain_text', text: 'Location Name' },
+				label: { type: 'plain_text', text: '* Location Name' },
 				element: {
 					type: 'plain_text_input',
 					action_id: 'street_address_input',
@@ -241,7 +263,7 @@ export const buildCreateEventModalBlocks = (options: createEventModalBlocksOptio
 			{
 				type: 'input',
 				block_id: 'city_block',
-				label: { type: 'plain_text', text: 'City' },
+				label: { type: 'plain_text', text: '* City' },
 				element: {
 					type: 'plain_text_input',
 					action_id: 'city_input',
@@ -252,7 +274,7 @@ export const buildCreateEventModalBlocks = (options: createEventModalBlocksOptio
 			{
 				type: 'input',
 				block_id: 'state_block',
-				label: { type: 'plain_text', text: 'State' },
+				label: { type: 'plain_text', text: '* State' },
 				element: {
 					type: 'plain_text_input',
 					action_id: 'state_input',

--- a/src/routes/api/slack/eventbot/submit/+server.ts
+++ b/src/routes/api/slack/eventbot/submit/+server.ts
@@ -19,7 +19,6 @@ import slugify from 'slugify';
 const slackClient = new WebClient(SLACK_BOT_TOKEN);
 
 export const POST: RequestHandler = async ({ request }: RequestEvent) => {
-	console.log('submit endpoint reached');
 	const formData = await request.formData();
 	const payloadString = formData.get('payload') as string;
 
@@ -29,7 +28,6 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 
 	const payload = JSON.parse(payloadString);
 	const state = payload.view.state;
-	console.log('🚀 ~ POST ~ state:', state);
 
 	let metadata;
 	try {
@@ -39,14 +37,11 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 				: payload.view.private_metadata;
 	} catch (err) {
 		console.error('Metadata parse error:', err);
-		console.log('Raw metadata:', payload.view.private_metadata);
 		return new Response('', { status: 200 });
 	}
 
-	console.log('Payload type:', payload.type);
 	if (payload.type === 'block_actions') {
 		const action = payload.actions[0];
-		console.log('action.action_id', action.action_id);
 
 		if (action.action_id === 'create_event') {
 			const groups: Group[] = await GroupModel.find({}, 'group slug');
@@ -92,10 +87,8 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 
 		if (action.action_id === 'group_select') {
 			const selectedGroup = action.selected_option.value;
-			console.log('🚀 ~ POST ~ selectedGroup:', selectedGroup);
 			const groupOptions = createGroupOptions(metadata.groups);
 			const locationOptions = createLocationOptions(metadata.locations);
-			// console.log('🚀 ~ POST ~ metadata:', metadata);
 
 			const updatedMetadata = {
 				...metadata,
@@ -138,10 +131,8 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 
 		if (action.action_id === 'location_select') {
 			const selectedLocation = action.selected_option.value;
-			console.log('🚀 ~ POST ~ selectedLocation:', selectedLocation);
 			const groupOptions = createGroupOptions(metadata.groups);
 			const locationOptions = createLocationOptions(metadata.locations);
-			// console.log('🚀 ~ POST ~ metadata:', metadata);
 
 			const updatedMetadata = {
 				...metadata,
@@ -220,6 +211,7 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 			const groupOptions = createGroupOptions(metadata.groups);
 			const locationOptions = createLocationOptions(metadata.locations);
 
+			// add warning block to modal if missing required info
 			return json({
 				response_action: 'update',
 				view: {
@@ -262,6 +254,7 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 		const startDate = new Date(startTime * 1000);
 		const endDate = new Date(endTime * 1000);
 
+		// complete event data from slack modal
 		const eventData = {
 			title,
 			groupSlug: selectedGroup === 'other-group' ? 'other-group' : selectedGroup,
@@ -297,7 +290,7 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 			locale: 'en'
 		});
 
-		// --- Save to MongoDB ---
+		// save to MongoDB
 		const newEvent: Event = {
 			groupSlug: eventData.groupSlug,
 			groupName,
@@ -328,10 +321,7 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 			console.error('Error saving to database', e);
 		}
 
-		console.log('📦 Raw event data:', eventData);
-		console.log('📦 Event data to save:', newEvent);
-
-		// --- Post announcement to Slack ---
+		// post announcement to Slack
 		try {
 			await slackClient.chat.postMessage({
 				channel: metadata.channel_id,
@@ -342,7 +332,7 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 			console.error('Failed to post announcement:', err);
 		}
 
-		// --- Return success modal (replaces the form) ---
+		// return success modal (replaces the form)
 		return json({
 			response_action: 'update',
 			view: {

--- a/src/routes/api/slack/eventbot/submit/+server.ts
+++ b/src/routes/api/slack/eventbot/submit/+server.ts
@@ -204,10 +204,9 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 		const announcement = getInputValue(state, 'announcement_block', 'announcement_input');
 
 		const selectedGroup =
-			state.values?.group_section_block?.group_select?.selected_option?.value ?? 'other-group';
+			state.values?.group_section_block?.group_select?.selected_option?.value ?? null;
 		const selectedLocation =
-			state.values?.location_section_block?.location_select?.selected_option?.value ??
-			'other-location';
+			state.values?.location_section_block?.location_select?.selected_option?.value ?? null;
 
 		let groupName;
 		let locationName = getInputValue(state, 'location_name_block', 'street_address_input');
@@ -215,6 +214,31 @@ export const POST: RequestHandler = async ({ request }: RequestEvent) => {
 		let locationCity = getInputValue(state, 'city_block', 'city_input');
 		let locationState = getInputValue(state, 'state_block', 'state_input');
 		let locationZip = getInputValue(state, 'zip_block', 'zip_input');
+
+		// check for submission errors on blocks that don't have built-in slack validation
+		if (!selectedGroup || !selectedLocation) {
+			const groupOptions = createGroupOptions(metadata.groups);
+			const locationOptions = createLocationOptions(metadata.locations);
+
+			return json({
+				response_action: 'update',
+				view: {
+					type: 'modal',
+					callback_id: 'create_event_modal',
+					private_metadata: JSON.stringify(metadata),
+					title: { type: 'plain_text', text: 'Create an Event' },
+					submit: { type: 'plain_text', text: 'Submit' },
+					close: { type: 'plain_text', text: 'Cancel' },
+					blocks: buildCreateEventModalBlocks({
+						groups: groupOptions,
+						locations: locationOptions,
+						showOtherGroupField: metadata.showOtherGroupField,
+						showOtherLocationFields: metadata.showOtherLocationFields,
+						isMissingField: true
+					})
+				}
+			});
+		}
 
 		if (selectedGroup !== 'other-group') {
 			const { group } = await GroupModel.findOne({ slug: selectedGroup }, 'group');


### PR DESCRIPTION
# 🚀 Description

A user could submit an event and leave out the group and locations, not be warned that these fields are required, and then slack would say it was submitted successfully while on the backend mongoose would prevent the event from writing to the database because those two fields are required.

## 💻 Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## ✅ Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
